### PR TITLE
Fixed token claims error by using standard claims

### DIFF
--- a/authentication/jwtTokenProvider.go
+++ b/authentication/jwtTokenProvider.go
@@ -10,9 +10,22 @@ var (
     defaultKeyFunc    jwt.Keyfunc = func(t *jwt.Token) (interface{}, error) { return jwtTestDefaultKey, nil }
 )
 
+type MyTimeClaims struct {
+    exp int64
+    jwt.StandardClaims
+}
+
+
 func GenerateToken(signingKey []byte) (string, error) {
-    token := jwt.New(jwt.SigningMethodHS256)
-    token.Claims["exp"] = time.Now().Add(time.Hour * 24).Unix()
+    claims := MyTimeClaims{
+        time.Now().Add(time.Hour * 24).Unix(),
+        jwt.StandardClaims{
+            ExpiresAt: 15000,
+            Issuer:    "website",
+        },
+    }
+
+    token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
     tokenString, ex := token.SignedString(signingKey)
 
     if ex != nil {


### PR DESCRIPTION
Token claims breaks because it's an interface type now.  This change fixes the interview project.

https://github.com/dgrijalva/jwt-go/blob/master/MIGRATION_GUIDE.md
